### PR TITLE
Udpate Docs for Directly Accessing The Summary Writer

### DIFF
--- a/docs/guide/tensorboard.rst
+++ b/docs/guide/tensorboard.rst
@@ -265,7 +265,7 @@ can get direct access to the underlying SummaryWriter in a callback:
         def _on_training_start(self):
             self._log_freq = 1000  # log every 1000 calls
 
-            output_formats = self.logger.Logger.CURRENT.output_formats
+            output_formats = self.logger.output_formats
             # Save reference to tensorboard formatter object
             # note: the failure case (not formatter found) is not handled here, should be done with try/except.
             self.tb_formatter = next(formatter for formatter in output_formats if isinstance(formatter, TensorBoardOutputFormat))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
update documentation for the part of _Directly Accessing The Summary Writer_, namely the way to get `output_formats` in class `SummaryWriterCallback`

## Motivation and Context
`Fix #820`  opened by myself
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
